### PR TITLE
Add view SQL link on front page

### DIFF
--- a/frontend/src/Components.js
+++ b/frontend/src/Components.js
@@ -267,6 +267,7 @@ function QueryPage(props) {
         </span>
         <a href={query.getUrlForMedia("csv")}>Download as CSV</a> -{" "}
         <a href={query.getUrlForMedia("json")}>View as JSON</a> -{" "}
+        <a href={query.getUrlForMedia("sql")}>View SQL Query</a> -{" "}
         <Save
           name="View"
           apiUrl={`${baseUrl}api/views/`}

--- a/frontend/src/Components.js
+++ b/frontend/src/Components.js
@@ -267,7 +267,7 @@ function QueryPage(props) {
         </span>
         <a href={query.getUrlForMedia("csv")}>Download as CSV</a> -{" "}
         <a href={query.getUrlForMedia("json")}>View as JSON</a> -{" "}
-        <a href={query.getUrlForMedia("sql")}>View SQL Query</a> -{" "}
+        <a href={query.getUrlForMedia("sql")} target="_blank">View SQL Query</a> -{" "}
         <Save
           name="View"
           apiUrl={`${baseUrl}api/views/`}


### PR DESCRIPTION
Apparently one of the most used features, also open in new tab by default, avoiding rerunning query after going back.