### PR TITLE
Custom admin site

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,8 @@ Settings
 +------------------------------------+---------------+---------------------------------+----------------------------------------------------------------------------------------------------+
 | ``DATA_BROWSER_APPS_EXPANDED``     | ``True``      |                                 | Are the app sections of the homepage model list expanded by default.                               |
 +------------------------------------+---------------+---------------------------------+----------------------------------------------------------------------------------------------------+
+| ``DATA_BROWSER_ADMIN_SITE``        | ``None``      |  `Admin Site`_                  | Specify an ``admin.AdminSite`` to use (default is ``admin.site``).                                 |
++------------------------------------+---------------+---------------------------------+----------------------------------------------------------------------------------------------------+
 
 
 Permissions
@@ -406,7 +408,37 @@ Then we need to tell the Data Browser we want ``p95`` on duration fields.
         lambda x: Percentile(0.95, x), DurationType
     )
 
+Admin Site
+----------
 
+You can create and use a custom ``admin.AdminSite`` (see https://docs.djangoproject.com/en/4.2/ref/contrib/admin/).
+
+To do so, in your ``settings.py``, add:
+
+.. code-block:: python
+
+    from django.contrib import admin
+
+    class BrowserAdminSite(admin.AdminSite):
+        pass
+
+    DATA_BROWSER_ADMIN_SITE = BrowserAdminSite(name='data_browser')
+
+Then, in any ``admin.py``, register the models as usually but using ``DATA_BROWSER_ADMIN_SITE``.
+
+For instance in ``myapp/admin.py``:
+
+.. code-block:: python
+
+    from django.contrib import admin
+    from django.conf import settings
+    from myapp.models import MyAdminModel, MyBrowsableModel
+
+    # register in admin only
+    admin.register(MyAdminModel)
+
+    # register in data browser only
+    settings.DATA_BROWSER_ADMIN_SITE.register(MyBrowsableModel)
 
 Version numbers
 ---------------

--- a/data_browser/common.py
+++ b/data_browser/common.py
@@ -25,6 +25,7 @@ class Settings:
         "DATA_BROWSER_USING_DB": "default",
         "DATA_BROWSER_ADMIN_OPTIONS": {},
         "DATA_BROWSER_APPS_EXPANDED": True,
+        "DATA_BROWSER_ADMIN_SITE": None,
     }
 
     def __getattr__(self, name):

--- a/data_browser/orm_admin.py
+++ b/data_browser/orm_admin.py
@@ -191,7 +191,8 @@ def _get_all_admin_fields(request):
         hidden_model_fields[model].update(_get_option(admin, "hide_fields", request))
 
     model_admins = {}
-    for model, model_admin in site._registry.items():
+    admin_site = settings.DATA_BROWSER_ADMIN_SITE or site
+    for model, model_admin in admin_site._registry.items():
         if visible(model_admin):
             model_admins[model] = model_admin
             all_model_fields[model].update(model_admin.get_list_display(request))


### PR DESCRIPTION
Hi tolomea,

Thank you for the great django-data-browser plugin !

Here is a minor contribution to let developers use a different AdminSite when needed.
It does not make the package more complicated to use as it keep using the default admin site if nothing is configured.
I actually need this difference to give an easy read-only access to some users whereas only technical staff has access to the admin.

I have also added a section in the README to explain how to use. Let me know if it is OK and feel free to correct the text.

Best,
ab